### PR TITLE
368 add internment place to obituary report view and pdf

### DIFF
--- a/app/(dashboard)/obituary/[reference]/page.tsx
+++ b/app/(dashboard)/obituary/[reference]/page.tsx
@@ -35,7 +35,15 @@ type ObituaryWithAllRelations = Prisma.ObituaryGetPayload<{
         country: true;
       };
     };
-    cemetery: true;
+    cemetery: {
+      include: {
+        city: {
+          include: {
+            country: true;
+          };
+        };
+      };
+    };
     periodical: true;
     fileBox: true;
     relatives: {
@@ -246,6 +254,21 @@ export default function ObituaryPage() {
                     {obituary.deathCity?.province || ""}
                     {obituary.deathCity?.province ? ", " : ""}
                     {obituary.deathCity?.country?.name || ""}
+                  </dd>
+                </div>
+                <div className="flex">
+                  <dt className="font-medium text-gray-600 w-1/3">
+                    Internment Place:
+                  </dt>
+                  <dd className="w-2/3">
+                    {[
+                      obituary.cemetery?.name,
+                      obituary.cemetery?.city?.name,
+                      obituary.cemetery?.city?.province,
+                      obituary.cemetery?.city?.country?.name
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
                   </dd>
                 </div>
               </dl>

--- a/lib/pdf-generation.ts
+++ b/lib/pdf-generation.ts
@@ -113,7 +113,15 @@ export async function generateObituaryPdfBytes(
         title: true,
         birthCity: { include: { country: true } },
         deathCity: { include: { country: true } },
-        cemetery: true,
+        cemetery: {
+          include: {
+            city: {
+              include: {
+                country: true
+              }
+            }
+          }
+        },
         periodical: true,
         fileBox: true,
         relatives: {
@@ -349,6 +357,15 @@ export async function generateObituaryPdfBytes(
       .filter(Boolean)
       .join(", ");
     drawObituaryKeyValuePair("Place of Death", deathPlace);
+    const internmentPlace = [
+      obituary.cemetery?.name,
+      obituary.cemetery?.city?.name,
+      obituary.cemetery?.city?.province,
+      obituary.cemetery?.city?.country?.name
+    ]
+      .filter(Boolean)
+      .join(", ");
+    drawObituaryKeyValuePair("Internment Place", internmentPlace);
     currentY += LINE_HEIGHT * 0.5;
 
     if (obituary.alsoKnownAs && obituary.alsoKnownAs.length > 0) {


### PR DESCRIPTION
# Add Internment Place to Obituary Report View and PDF

## Summary
Added "Internment Place" field to the obituary report view and PDF generation, displaying cemetery information in the format: "Cemetery Name, City, Province, Country".

## Changes Made

### Frontend (Obituary Report View)
- Updated `ObituaryWithAllRelations` type to include cemetery city and country relations
- Added Internment Place field in Personal Information section after "Place of Death"
- Implemented smart formatting that handles null/undefined values gracefully

### Backend (Database Queries)
- Enhanced Prisma queries in `actions.ts` to include nested cemetery → city → country relations
- Updated `fetchObituaryByReferenceAction` and `getPublicObituaryByHash` functions

### PDF Generation
- Modified `lib/pdf-generation.ts` to include cemetery city/country data in queries
- Added Internment Place field to PDF output for consistency with web view

## Technical Implementation
- Uses `filter(Boolean).join(", ")` to display only available cemetery information
- Maintains type safety with proper TypeScript interfaces
- Ensures consistency between web view and PDF generation
- Follows existing code patterns and formatting conventions

## Example Output

Internment Place: Lakeview Memorial Gardens Cemetery, Kelowna, BC, Canada

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ Linting passes with no issues
- ✅ Maintains backward compatibility for records without cemetery data

This enhancement improves the completeness of obituary reports by including burial/internment location information that was previously available in the database but not displayed to users.