### PR TITLE
367 publication management not allowing adding location

### DIFF
--- a/app/(dashboard)/setup/page.tsx
+++ b/app/(dashboard)/setup/page.tsx
@@ -20,6 +20,7 @@ import { OrdersAdministration } from "./orders-administration";
 import { PeriodicalAdministration } from "./periodical-administration";
 import { RelationshipAdministration } from "./relationship-administration";
 import { TitleAdministration } from "./title-administration";
+import { SharedDataProvider } from "./shared-data-context";
 
 export default async function SetupPage() {
   const { userId } = auth();
@@ -47,7 +48,7 @@ export default async function SetupPage() {
               <FileBoxAdministration />
               <BatchNumberAdministration />
               {isAdmin && (
-                <>
+                <SharedDataProvider>
                   <BulkUpload />
                   <OrdersAdministration />
                   <CountryAdministration />
@@ -58,7 +59,7 @@ export default async function SetupPage() {
                   <TitleAdministration />
                   <GenealogistAdministration />
                   <AdminBackup />
-                </>
+                </SharedDataProvider>
               )}
             </CardContent>
           </CardHeader>

--- a/app/(dashboard)/setup/periodical-administration.tsx
+++ b/app/(dashboard)/setup/periodical-administration.tsx
@@ -35,6 +35,7 @@ import AddPeriodicalDialog from "./add-periodical-dialog";
 import EditPeriodicalDialog from "./edit-periodical-dialog";
 import { CityWithRelations, PeriodicalWithRelations } from "@/types/prisma";
 import { RelatedPeriodicalObituariesDialog } from "./related-periodical-obituaries-dialog";
+import { useSharedData } from "./shared-data-context";
 import {
   Select,
   SelectContent,
@@ -51,12 +52,12 @@ interface PeriodicalData {
 // Use only Prisma types to include to Periodical types its relationship City
 
 export function PeriodicalAdministration() {
+  const { cities, initializeData, isInitialized } = useSharedData();
   const [periodicalData, setPeriodicalData] = useState<PeriodicalData>({
     periodicals: [],
     totalCount: 0,
     totalPages: 0
   });
-  const [cities, setCities] = useState<CityWithRelations[]>([]);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [searchName, setSearchName] = useState("");
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -150,20 +151,6 @@ export function PeriodicalAdministration() {
     }
   };
 
-  const fetchCities = async () => {
-    try {
-      const citiesResult = await getCities();
-      setCities(citiesResult);
-    } catch (error) {
-      toast({
-        title: "Error fetching cities",
-        description:
-          error instanceof Error ? error.message : "An unknown error occurred",
-        variant: "destructive"
-      });
-    }
-  };
-
   useEffect(() => {
     // Only fetch when expanded
     if (isExpanded) {
@@ -171,11 +158,18 @@ export function PeriodicalAdministration() {
     }
   }, [currentPage, isExpanded, itemsPerPage]);
 
+  // Initialize shared data when component expands
   useEffect(() => {
-    if (isExpanded) {
-      fetchCities();
+    if (isExpanded && !isInitialized) {
+      initializeData().catch(error => {
+        toast({
+          title: "Error",
+          description: "Failed to initialize shared data",
+          variant: "destructive"
+        });
+      });
     }
-  }, [isExpanded]);
+  }, [isExpanded, isInitialized, initializeData, toast]);
 
   const handleSearch = async () => {
     if (!isExpanded) return;

--- a/app/(dashboard)/setup/shared-data-context.tsx
+++ b/app/(dashboard)/setup/shared-data-context.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode
+} from "react";
+import { Prisma } from "@prisma/client";
+import { getCities, getCountries } from "./actions";
+
+type CityWithCountry = Prisma.CityGetPayload<{ include: { country: true } }>;
+type Country = { id: number; name: string };
+
+interface SharedDataContextType {
+  // Data
+  cities: CityWithCountry[];
+  countries: Country[];
+
+  // Formatted data for compatibility with existing components
+  formattedCities: {
+    id: number;
+    name: string;
+    province?: string | null;
+    country: { name: string };
+  }[];
+
+  // Loading states
+  isCitiesLoading: boolean;
+  isCountriesLoading: boolean;
+
+  // Refresh functions
+  refreshCities: () => Promise<void>;
+  refreshCountries: () => Promise<void>;
+  refreshAll: () => Promise<void>;
+
+  // Initialization
+  isInitialized: boolean;
+  initializeData: () => Promise<void>;
+}
+
+const SharedDataContext = createContext<SharedDataContextType | undefined>(
+  undefined
+);
+
+export function useSharedData() {
+  const context = useContext(SharedDataContext);
+  if (context === undefined) {
+    throw new Error("useSharedData must be used within a SharedDataProvider");
+  }
+  return context;
+}
+
+interface SharedDataProviderProps {
+  children: ReactNode;
+}
+
+export function SharedDataProvider({ children }: SharedDataProviderProps) {
+  const [cities, setCities] = useState<CityWithCountry[]>([]);
+  const [countries, setCountries] = useState<Country[]>([]);
+
+  // Compute formatted cities for compatibility
+  const formattedCities = cities
+    .filter(city => city.country) // Only include cities with countries
+    .map(city => ({
+      id: city.id,
+      name: city.name || "",
+      province: city.province,
+      country: { name: city.country!.name }
+    }));
+  const [isCitiesLoading, setIsCitiesLoading] = useState(false);
+  const [isCountriesLoading, setIsCountriesLoading] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  const refreshCities = useCallback(async () => {
+    setIsCitiesLoading(true);
+    try {
+      const citiesData = await getCities();
+      setCities(citiesData);
+    } catch (error) {
+      console.error("Error refreshing cities:", error);
+      throw error;
+    } finally {
+      setIsCitiesLoading(false);
+    }
+  }, []);
+
+  const refreshCountries = useCallback(async () => {
+    setIsCountriesLoading(true);
+    try {
+      const countriesResult = await getCountries(1, 1000);
+      setCountries(countriesResult.countries);
+    } catch (error) {
+      console.error("Error refreshing countries:", error);
+      throw error;
+    } finally {
+      setIsCountriesLoading(false);
+    }
+  }, []);
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refreshCities(), refreshCountries()]);
+  }, [refreshCities, refreshCountries]);
+
+  const initializeData = useCallback(async () => {
+    if (isInitialized) return;
+
+    try {
+      await refreshAll();
+      setIsInitialized(true);
+    } catch (error) {
+      console.error("Error initializing shared data:", error);
+      throw error;
+    }
+  }, [isInitialized, refreshAll]);
+
+  const value: SharedDataContextType = {
+    cities,
+    countries,
+    formattedCities,
+    isCitiesLoading,
+    isCountriesLoading,
+    refreshCities,
+    refreshCountries,
+    refreshAll,
+    isInitialized,
+    initializeData
+  };
+
+  return (
+    <SharedDataContext.Provider value={value}>
+      {children}
+    </SharedDataContext.Provider>
+  );
+}


### PR DESCRIPTION
# Fix cache synchronization issue between management components

## Problem
Management components (Location, Cemetery, Periodical) maintained independent cached data, causing inconsistencies when shared data (cities/countries) was modified. Adding a location in Location Management wouldn't appear in other components' dropdowns until manual refresh.

## Solution
Implemented shared data context pattern:

- **Created `SharedDataProvider`**: Centralized state management for cities and countries data
- **Updated Setup page**: Wrapped admin components with shared context provider  
- **Modified components**: Location, Cemetery, and Periodical Management now use shared cache instead of local state
- **Added cache invalidation**: Components call `refreshCities()` after mutations to sync all consumers

## Key Changes
- `app/(dashboard)/setup/shared-data-context.tsx` - New shared context implementation
- `app/(dashboard)/setup/page.tsx` - Added SharedDataProvider wrapper
- `app/(dashboard)/setup/location-administration.tsx` - Uses shared context, calls refresh on mutations
- `app/(dashboard)/setup/cemetery-administration.tsx` - Uses shared cities data
- `app/(dashboard)/setup/periodical-administration.tsx` - Uses shared cities data

## Benefits
- ✅ Real-time data synchronization across all management components
- ✅ Eliminated stale cache issues
- ✅ Improved performance with centralized data fetching
- ✅ Maintained backward compatibility with existing dialogs

## Testing
- Build passes with no TypeScript errors
- All components maintain existing functionality
- Cache updates propagate immediately across components